### PR TITLE
change suggested-namespace for must-gather-operator

### DIFF
--- a/config/manifests/bases/must-gather-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/must-gather-operator.clusterserviceversion.yaml
@@ -10,7 +10,7 @@ metadata:
     createdAt: 11/14/2019
     description: This operator provides a facility to easily upload must-gather reports
       to a Red Hat case.
-    operatorframework.io/suggested-namespace: global-load-balancer-operator
+    operatorframework.io/suggested-namespace: must-gather-operator
     repository: https://github.com/redhat-cop/must-gather-operator
     support: Best Effort
     operators.openshift.io/infrastructure-features: '["Disconnected"]'


### PR DESCRIPTION
The must-gather operator is currently using global-load-balancer-operator as a suggested namespace for operator
According to feedback I received it would be great to use a more relevant name like must-gather-operator 