### PR TITLE
[upload](logic-change): Enhanched upload to split on size (default 1G) for large clusters

### DIFF
--- a/config/docker/upload
+++ b/config/docker/upload
@@ -16,6 +16,7 @@ FILENAME_PREFIX=${FILENAME_PREFIX:="must-gather"}
 CASE_COMMENT=${CASE_COMMENT:="File upload from must-gather tool"}
 CURRENT_TIMESTAMP=$(date --utc +%Y%m%d_%H%M%SZ)
 PRIVATE_ATTACHMENT_FLAG=""
+PARTSIZE=${PARTSIZE:-1000000000} # in bytes to avoid conversion issues
 CSP_FILENAME=${FILENAME_PREFIX}-${CURRENT_TIMESTAMP}.tar.gz
 CSP_FILE="${must_gather_upload}/${CSP_FILENAME}"
 
@@ -32,14 +33,25 @@ fi
 
 tar cvaf "$must_gather_upload/${CSP_FILENAME}" $must_gather_output/
 
-echo "Uploading '${CSP_FILENAME}' to Red Hat Customer Portal case ${caseid}"
+SIZE=$(stat --printf="%s" ${CSP_FILENAME})
+if [ "${SIZE}" -gt "${PARTSIZE}" ] ; then
+    echo "Splitting must-gather on size"
+    split -b ${PARTSIZE} ${CSP_FILENAME} ${CSP_FILENAME}- -d 
+    UPLOADS=$(ls ${CSP_FILENAME}-*)
+else
+    UPLOADS=${CSP_FILENAME}
+fi 
 
-status_code=$(curl --write-out %{http_code} -o $must_gather_upload/curl.log -u ${username}:${password} -X POST -F "file=@${CSP_FILE}" "https://api.access.redhat.com/rs/cases/${caseid}/attachments${PRIVATE_ATTACHMENT_FLAG}" -H 'Accept: text/plain' --form-string "description=${CASE_COMMENT}")
-cat $must_gather_upload/curl.log
-if [[ "$status_code" -ne 201 ]];
-then
-  echo "Error: Upload to Red Hat Customer Portal did not return expected status code. Expected: 201. Actual: $status_code"
-  exit 1
-fi
+for FILEPART in ${UPLOADS} ; do 
+    echo "Uploading '${FILEPART}' to Red Hat Customer Portal case ${caseid}"
 
-echo "Successfully added '${CSP_FILENAME}' to Red Hat Customer Portal case ${caseid}"
+    status_code=$(curl --write-out %{http_code} -o $must_gather_upload/curl.log -u ${username}:${password} -X POST -F "file=@${FILEPART}" "https://api.access.redhat.com/rs/cases/${caseid}/attachments${PRIVATE_ATTACHMENT_FLAG}" -H 'Accept: text/plain' --form-string "description=${CASE_COMMENT}")
+    cat $must_gather_upload/curl.log
+    if [[ "$status_code" -ne 201 ]];
+    then
+      echo "Error: Upload to Red Hat Customer Portal did not return expected status code. Expected: 201. Actual: $status_code"
+      exit 1
+    fi
+
+    echo "Successfully added '${FILEPART}' to Red Hat Customer Portal case ${caseid}"
+done


### PR DESCRIPTION
As mentioned in issue https://github.com/redhat-cop/must-gather-operator/issues/36 as well as reported by some of my customers, large clusters cannot upload must gather data due to limitations of upload size. 

The implementation defaults to 1G and specifically 1000000000 bytes to avoid converting issues and if the file is smaller than `PARTSIZE` environment variable the behavior is unchanged.

### Example: small Cluster must-gather < 1G 
```
$ PARTSIZE=${PARTSIZE:-1000000000} # in bytes to avoid conversion issues
if [ "${SIZE}" -gt "${PARTSIZE}" ] ; then
    echo "Splitting must-gather on size"
    split -b ${PARTSIZE} ${CSP_FILENAME} ${CSP_FILENAME}- -d
    UPLOADS=$(ls ${CSP_FILENAME}-*)
else
    UPLOADS=${CSP_FILENAME}
fi 
$ for FILEPART in ${UPLOADS} ; do 
    echo "Uploading '${FILEPART}' to Red Hat Customer Portal case ${caseid}"

done
Uploading 'must-gather.tar.gz' to Red Hat Customer Portal case 123456
```

### Example: large Cluster must-gather > 1G 
```
$ PARTSIZE=${PARTSIZE:-1000000000} # in bytes to avoid conversion issues
if [ "${SIZE}" -gt "${PARTSIZE}" ] ; then
    echo "Splitting must-gather on size"
    split -b ${PARTSIZE} ${CSP_FILENAME} ${CSP_FILENAME}- -d
    UPLOADS=$(ls ${CSP_FILENAME}-*)
else
    UPLOADS=${CSP_FILENAME}
fi 
Splitting must-gather on size
$ for FILEPART in ${UPLOADS} ; do 
    echo "Uploading '${FILEPART}' to Red Hat Customer Portal case ${caseid}"

done
Uploading 'must-gather.tar.gz-00' to Red Hat Customer Portal case 123456
Uploading 'must-gather.tar.gz-01' to Red Hat Customer Portal case 123456
Uploading 'must-gather.tar.gz-02' to Red Hat Customer Portal case 123456
Uploading 'must-gather.tar.gz-03' to Red Hat Customer Portal case 123456
Uploading 'must-gather.tar.gz-04' to Red Hat Customer Portal case 123456
```